### PR TITLE
Fixes logging in sprinklr_serial, adds 3 second delay to scheduler wh…

### DIFF
--- a/api.py
+++ b/api.py
@@ -15,7 +15,6 @@ logger = logging.getLogger("api_log")
 app = FastAPI()
 
 # TODO: api path to update sprinkler names
-# TODO: add log level to api.conf
 
 class ScheduleItem(TypedDict):
     zone: int

--- a/scheduler.py
+++ b/scheduler.py
@@ -87,6 +87,7 @@ def check_system_status():
                     logging.debug(f"System is in error state: {r.json()['message']}")
                     return False, -1
                 logging.debug(f"Received status: {r.json()['systemStatus']}, retrying")
+                time.sleep(180)  # Sleep for 3 minutes (180 seconds)
         except Exception as e:
             logging.debug(f"Attempt {attempt + 1}: Caught exception {e}")
             return False, -1

--- a/sprinklr_serial.py
+++ b/sprinklr_serial.py
@@ -99,11 +99,11 @@ def test_awake():
             time.sleep(0.3)
 
     except IOError as exc:
-        logging.error(f'sprinklr_serial: Caught file I/O error {str(exc)}')
+        logger.error(f'sprinklr_serial: Caught file I/O error {str(exc)}')
         raise exc
     # print('Command failed')
     arduino.close()
-    logging.error('sprinklr_serial: Unable to connect to arduino')
+    logger.error('sprinklr_serial: Unable to connect to arduino')
     return False
 
 # Handshake with Arduino
@@ -123,14 +123,14 @@ def handshake(arduino, conn_id):
         data = False
         attempt += 1
         # print(f'Writing: {byteStr}')
-        logging.debug(f'sprinklr_serial: Writing: {byteStr}')
+        logger.debug(f'sprinklr_serial: Writing: {byteStr}')
         arduino.write(byteStr)
         arduino.flush()
         time.sleep(0.1)
         while (arduino.inWaiting() > 0):   
             data = arduino.read(7)
             # print(f'Received {data}')
-            logging.debug(f'sprinklr_serial: Received {data}')
+            logger.debug(f'sprinklr_serial: Received {data}')
         if not data:
             time.sleep(0.1)
             continue
@@ -146,7 +146,7 @@ def handshake(arduino, conn_id):
         else:
             time.sleep(0.1)
     # print('Handshake failed')
-    logging.error('sprinklr_serial: Handshake failed')
+    logger.error('sprinklr_serial: Handshake failed')
     return False
 
 
@@ -183,10 +183,10 @@ def writeCmd(cmd):
                     time.sleep(0.5)
         arduino.close()
     except IOError as exc:
-        logging.error(f'sprinklr_serial: Caught file I/O error {str(exc)}')
+        logger.error(f'sprinklr_serial: Caught file I/O error {str(exc)}')
         raise exc
     # print('Command failed')
-    logging.error('sprinklr_serial: Command failed')
+    logger.error('sprinklr_serial: Command failed')
     return False
 
 # Testing function


### PR DESCRIPTION
More robust logging, with differing log levels defined in api.conf
Adds 3 second delay before retrying to scheduler if encountering USB error. This seems to be necessary if the serial port hasn't been used in several hours. 